### PR TITLE
Add Google Drive MCP server placeholder in Golang

### DIFF
--- a/google_drive_mcp/main.go
+++ b/google_drive_mcp/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// Placeholder for Google Drive MCP server in Golang
+func main() {
+	fmt.Println("Google Drive MCP server starting...")
+
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Google Drive MCP server is running!")
+	})
+
+	// TODO: Implement Google Drive authentication and file management endpoints
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
This PR adds an initial placeholder for a Google Drive MCP server written in Golang. It includes a basic HTTP server and a health check endpoint. Further implementation is needed for Google Drive authentication and file management endpoints.